### PR TITLE
Removed `:email` from serializer

### DIFF
--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,3 +1,3 @@
 class UserSerializer < ActiveModel::Serializer
-  attributes :id, :email, :username, :created_at, :updated_at
+  attributes :id, :username, :password, :created_at, :updated_at
 end


### PR DESCRIPTION
- Fix 500 error:
`NoMethodError (undefined method `email' for #<User:0x007f98d1717ac0>)`